### PR TITLE
Cropping margins when exporting images

### DIFF
--- a/src/context/export-image-context/export-image-provider.tsx
+++ b/src/context/export-image-context/export-image-provider.tsx
@@ -28,9 +28,7 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
     const exportImage: ExportImageContext['exportImage'] = useCallback(
         async (type, { includePatternBG, transparent, scale }) => {
             try {
-                console.log(
-                    `[export-provider] Экспорт изображения типа: ${type}`
-                );
+                console.log(`[export-provider] Exporting image type: ${type}`);
 
                 showLoader({
                     animated: false,
@@ -151,14 +149,14 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
 
                 const imageCreateFn = imageCreatorMap[type];
                 console.log(
-                    `[export-provider] Вызываем функцию создания изображения для типа: ${type}`
+                    `[export-provider] Calling image creation function for type: ${type}`
                 );
 
                 let dataUrl;
 
                 if (type === 'svg') {
                     try {
-                        console.log('[export-provider] Начинаем создание SVG');
+                        console.log('[export-provider] Starting SVG creation');
 
                         // Для SVG используем специальные параметры
                         dataUrl = await toSvg(viewportElement, {
@@ -175,7 +173,7 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
                                 transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
                             },
                             filter: (node) => {
-                                // Исключаем некоторые элементы, которые могут вызывать проблемы
+                                // Exclude certain elements that may cause problems
                                 const excludeClasses = [
                                     'react-flow__minimap',
                                     'react-flow__controls',
@@ -188,33 +186,33 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
                         });
 
                         console.log(
-                            '[export-provider] SVG создан успешно, длина data URL:',
+                            '[export-provider] SVG created successfully, data URL length:',
                             dataUrl?.length || 0
                         );
 
-                        // Сразу запускаем скачивание SVG
+                        // Start SVG download immediately
                         console.log(
-                            '[export-provider] Пытаемся скачать SVG напрямую из провайдера'
+                            '[export-provider] Attempting to download SVG directly from provider'
                         );
 
                         try {
-                            // Используем fetch для получения данных SVG
+                            // Use fetch to retrieve SVG data
                             console.log(
-                                '[export-provider] Используем fetch для получения SVG'
+                                '[export-provider] Using fetch to get SVG data'
                             );
                             const response = await fetch(dataUrl);
                             const blob = await response.blob();
                             console.log(
-                                '[export-provider] Получен blob, размер:',
+                                '[export-provider] Received blob, size:',
                                 blob.size
                             );
 
                             // Создаем URL для скачивания
                             const url = URL.createObjectURL(blob);
 
-                            // Приоритет - скачивание SVG
+                            // Priority - direct SVG download
                             console.log(
-                                '[export-provider] Приоритетно используем прямое скачивание SVG'
+                                '[export-provider] Using direct SVG download as priority'
                             );
 
                             // Создаем ссылку для скачивания
@@ -225,42 +223,42 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
                             document.body.appendChild(link);
 
                             console.log(
-                                '[export-provider] Запускаем скачивание SVG'
+                                '[export-provider] Starting SVG download'
                             );
                             link.click();
 
-                            // Даем время на скачивание
+                            // Allow time for download
                             await new Promise((resolve) =>
                                 setTimeout(resolve, 1000)
                             ); // Увеличиваем время ожидания
 
                             document.body.removeChild(link);
 
-                            // Очищаем URL после задержки
+                            // Clean up URL after delay
                             setTimeout(() => URL.revokeObjectURL(url), 5000);
 
                             console.log(
-                                '[export-provider] SVG обработка завершена'
+                                '[export-provider] SVG processing completed'
                             );
                         } catch (downloadError) {
                             console.error(
-                                '[export-provider] Ошибка при скачивании SVG:',
+                                '[export-provider] Error downloading SVG:',
                                 downloadError
                             );
 
-                            // Дополнительная попытка - открыть SVG в новом окне
+                            // Fallback option - open SVG in new window
                             try {
                                 const newWindow = window.open(
                                     dataUrl,
                                     '_blank'
                                 );
                                 console.log(
-                                    '[export-provider] Попытка открыть SVG в новом окне:',
-                                    newWindow ? 'успешно' : 'неудача'
+                                    '[export-provider] Attempt to open SVG in new window:',
+                                    newWindow ? 'success' : 'failed'
                                 );
                             } catch (windowError) {
                                 console.error(
-                                    '[export-provider] Не удалось открыть SVG в новом окне:',
+                                    '[export-provider] Failed to open SVG in new window:',
                                     windowError
                                 );
                             }
@@ -268,11 +266,11 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
                     } catch (error) {
                         const svgError = error as Error;
                         console.error(
-                            '[export-provider] Ошибка при создании SVG:',
+                            '[export-provider] Error creating SVG:',
                             svgError
                         );
                         throw new Error(
-                            `Ошибка при создании SVG: ${svgError.message || 'Неизвестная ошибка'}`
+                            `Error creating SVG: ${svgError.message || 'Unknown error'}`
                         );
                     }
                 } else {

--- a/src/context/export-image-context/export-image-provider.tsx
+++ b/src/context/export-image-context/export-image-provider.tsx
@@ -28,6 +28,10 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
     const exportImage: ExportImageContext['exportImage'] = useCallback(
         async (type, { includePatternBG, transparent, scale }) => {
             try {
+                console.log(
+                    `[export-provider] Экспорт изображения типа: ${type}`
+                );
+
                 showLoader({
                     animated: false,
                 });
@@ -146,23 +150,151 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
                 );
 
                 const imageCreateFn = imageCreatorMap[type];
-                const dataUrl = await imageCreateFn(viewportElement, {
-                    backgroundColor: transparent
-                        ? 'transparent'
-                        : effectiveTheme === 'light'
-                          ? '#ffffff'
-                          : '#1a1a1a',
-                    width: reactFlowBounds.width,
-                    height: reactFlowBounds.height,
-                    style: {
-                        width: `${reactFlowBounds.width}px`,
-                        height: `${reactFlowBounds.height}px`,
-                        transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
-                    },
-                    quality: 1,
-                    pixelRatio: scale,
-                    skipFonts: true,
-                });
+                console.log(
+                    `[export-provider] Вызываем функцию создания изображения для типа: ${type}`
+                );
+
+                let dataUrl;
+
+                if (type === 'svg') {
+                    try {
+                        console.log('[export-provider] Начинаем создание SVG');
+
+                        // Для SVG используем специальные параметры
+                        dataUrl = await toSvg(viewportElement, {
+                            backgroundColor: transparent
+                                ? 'transparent'
+                                : effectiveTheme === 'light'
+                                  ? '#ffffff'
+                                  : '#1a1a1a',
+                            width: reactFlowBounds.width,
+                            height: reactFlowBounds.height,
+                            style: {
+                                width: `${reactFlowBounds.width}px`,
+                                height: `${reactFlowBounds.height}px`,
+                                transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+                            },
+                            filter: (node) => {
+                                // Исключаем некоторые элементы, которые могут вызывать проблемы
+                                const excludeClasses = [
+                                    'react-flow__minimap',
+                                    'react-flow__controls',
+                                ];
+                                return !excludeClasses.some((className) =>
+                                    node.classList?.contains(className)
+                                );
+                            },
+                            skipFonts: true,
+                        });
+
+                        console.log(
+                            '[export-provider] SVG создан успешно, длина data URL:',
+                            dataUrl?.length || 0
+                        );
+
+                        // Сразу запускаем скачивание SVG
+                        console.log(
+                            '[export-provider] Пытаемся скачать SVG напрямую из провайдера'
+                        );
+
+                        try {
+                            // Используем fetch для получения данных SVG
+                            console.log(
+                                '[export-provider] Используем fetch для получения SVG'
+                            );
+                            const response = await fetch(dataUrl);
+                            const blob = await response.blob();
+                            console.log(
+                                '[export-provider] Получен blob, размер:',
+                                blob.size
+                            );
+
+                            // Создаем URL для скачивания
+                            const url = URL.createObjectURL(blob);
+
+                            // Приоритет - скачивание SVG
+                            console.log(
+                                '[export-provider] Приоритетно используем прямое скачивание SVG'
+                            );
+
+                            // Создаем ссылку для скачивания
+                            const link = document.createElement('a');
+                            link.download = 'diagram.svg';
+                            link.href = url;
+                            link.style.display = 'none';
+                            document.body.appendChild(link);
+
+                            console.log(
+                                '[export-provider] Запускаем скачивание SVG'
+                            );
+                            link.click();
+
+                            // Даем время на скачивание
+                            await new Promise((resolve) =>
+                                setTimeout(resolve, 1000)
+                            ); // Увеличиваем время ожидания
+
+                            document.body.removeChild(link);
+
+                            // Очищаем URL после задержки
+                            setTimeout(() => URL.revokeObjectURL(url), 5000);
+
+                            console.log(
+                                '[export-provider] SVG обработка завершена'
+                            );
+                        } catch (downloadError) {
+                            console.error(
+                                '[export-provider] Ошибка при скачивании SVG:',
+                                downloadError
+                            );
+
+                            // Дополнительная попытка - открыть SVG в новом окне
+                            try {
+                                const newWindow = window.open(
+                                    dataUrl,
+                                    '_blank'
+                                );
+                                console.log(
+                                    '[export-provider] Попытка открыть SVG в новом окне:',
+                                    newWindow ? 'успешно' : 'неудача'
+                                );
+                            } catch (windowError) {
+                                console.error(
+                                    '[export-provider] Не удалось открыть SVG в новом окне:',
+                                    windowError
+                                );
+                            }
+                        }
+                    } catch (error) {
+                        const svgError = error as Error;
+                        console.error(
+                            '[export-provider] Ошибка при создании SVG:',
+                            svgError
+                        );
+                        throw new Error(
+                            `Ошибка при создании SVG: ${svgError.message || 'Неизвестная ошибка'}`
+                        );
+                    }
+                } else {
+                    // Для других типов используем стандартный подход
+                    dataUrl = await imageCreateFn(viewportElement, {
+                        backgroundColor: transparent
+                            ? 'transparent'
+                            : effectiveTheme === 'light'
+                              ? '#ffffff'
+                              : '#1a1a1a',
+                        width: reactFlowBounds.width,
+                        height: reactFlowBounds.height,
+                        style: {
+                            width: `${reactFlowBounds.width}px`,
+                            height: `${reactFlowBounds.height}px`,
+                            transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+                        },
+                        quality: 1,
+                        pixelRatio: scale,
+                        skipFonts: true,
+                    });
+                }
 
                 // Remove temporary SVG after getting the image
                 if (

--- a/src/dialogs/export-image-dialog/export-image-dialog.tsx
+++ b/src/dialogs/export-image-dialog/export-image-dialog.tsx
@@ -16,6 +16,7 @@ import type { BaseDialogProps } from '../common/base-dialog-props';
 import { useTranslation } from 'react-i18next';
 import type { ImageType } from '@/context/export-image-context/export-image-context';
 import { useExportImage } from '@/hooks/use-export-image';
+import { autoCropImage } from '@/utils/image-utils';
 import { Checkbox } from '@/components/checkbox/checkbox';
 import {
     Accordion,
@@ -30,6 +31,7 @@ export interface ExportImageDialogProps extends BaseDialogProps {
 
 const DEFAULT_INCLUDE_PATTERN_BG = true;
 const DEFAULT_TRANSPARENT = false;
+const DEFAULT_AUTO_CROP = true;
 const DEFAULT_SCALE = '2';
 export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
     dialog,
@@ -42,6 +44,7 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
     );
     const [transparent, setTransparent] =
         useState<boolean>(DEFAULT_TRANSPARENT);
+    const [autoCrop, setAutoCrop] = useState<boolean>(DEFAULT_AUTO_CROP);
     const { exportImage } = useExportImage();
 
     useEffect(() => {
@@ -49,16 +52,116 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
         setScale(DEFAULT_SCALE);
         setIncludePatternBG(DEFAULT_INCLUDE_PATTERN_BG);
         setTransparent(DEFAULT_TRANSPARENT);
+        setAutoCrop(DEFAULT_AUTO_CROP);
     }, [dialog.open]);
+
+    // Выключаем опцию обрезки, если включен фоновый паттерн
+    useEffect(() => {
+        if (includePatternBG && autoCrop) {
+            setAutoCrop(false);
+        }
+    }, [includePatternBG, autoCrop]);
     const { closeExportImageDialog } = useDialog();
 
-    const handleExport = useCallback(() => {
-        exportImage(format, {
-            transparent,
-            includePatternBG,
-            scale: Number(scale),
-        });
-    }, [exportImage, format, includePatternBG, transparent, scale]);
+    const handleExport = useCallback(async () => {
+        try {
+            console.log(
+                `[export-dialog] Экспорт диаграммы в формате: ${format}`
+            );
+
+            // Отдельная обработка для формата SVG
+            if (format === 'svg') {
+                console.log(
+                    '[export-dialog] Используем метод загрузки через fetch для SVG'
+                );
+
+                try {
+                    // Получаем SVG данные
+                    const imageUrl = await exportImage('svg', {
+                        transparent,
+                        includePatternBG,
+                        scale: Number(scale),
+                    });
+
+                    console.log(
+                        '[export-dialog] Получен SVG URL, длина:',
+                        imageUrl.length
+                    );
+
+                    // Используем fetch для получения данных SVG
+                    const response = await fetch(imageUrl);
+                    const blob = await response.blob();
+
+                    console.log(
+                        '[export-dialog] Создан blob для SVG, размер:',
+                        blob.size
+                    );
+
+                    // Создаем файл и начинаем загрузку
+                    const url = window.URL.createObjectURL(blob);
+                    const filename = 'diagram.svg';
+
+                    // Создаем новый элемент ссылки для загрузки
+                    const downloadLink = document.createElement('a');
+                    downloadLink.href = url;
+                    downloadLink.download = filename;
+                    downloadLink.style.display = 'none';
+
+                    // Добавляем в DOM, кликаем и удаляем
+                    document.body.appendChild(downloadLink);
+                    console.log('[export-dialog] Начинаем загрузку SVG файла');
+                    downloadLink.click();
+
+                    // Даем время на скачивание перед удалением
+                    await new Promise((resolve) => setTimeout(resolve, 300));
+
+                    document.body.removeChild(downloadLink);
+                    window.URL.revokeObjectURL(url);
+                    console.log('[export-dialog] Загрузка SVG завершена');
+
+                    return true;
+                } catch (error) {
+                    console.error('Ошибка при экспорте SVG:', error);
+                    throw error;
+                }
+            } else {
+                // Для PNG и JPEG применяем стандартный метод экспорта
+                console.log(
+                    `[export-dialog] Экспорт ${format} с параметрами: масштаб=${scale}, прозрачность=${transparent}`
+                );
+
+                // Получаем изображение
+                const imageUrl = await exportImage(format, {
+                    transparent,
+                    includePatternBG,
+                    scale: Number(scale),
+                });
+
+                // Применяем автоматическую обрезку, если нужно
+                let finalImageUrl;
+
+                if (autoCrop && !includePatternBG) {
+                    console.log(
+                        '[export-dialog] Применяем автоматическую обрезку'
+                    );
+                    finalImageUrl = await autoCropImage(imageUrl, 50, format);
+                } else {
+                    finalImageUrl = imageUrl;
+                }
+
+                // Создаем ссылку для скачивания
+                const link = document.createElement('a');
+                link.download = `diagram.${format}`;
+                link.href = finalImageUrl;
+                document.body.appendChild(link);
+                console.log(`[export-dialog] Запуск скачивания ${format}`);
+                link.click();
+                document.body.removeChild(link);
+            }
+        } catch (error) {
+            console.error('Ошибка при экспорте изображения:', error);
+        }
+    }, [exportImage, format, includePatternBG, transparent, scale, autoCrop]);
 
     const scaleOptions: SelectBoxOption[] = useMemo(
         () =>
@@ -154,6 +257,36 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
                                             </span>
                                         </div>
                                     </div>
+                                    <div className="flex items-start gap-3">
+                                        <Checkbox
+                                            id="auto-crop-checkbox"
+                                            className="mt-1 data-[state=checked]:border-pink-600 data-[state=checked]:bg-pink-600 data-[state=checked]:text-white"
+                                            checked={autoCrop}
+                                            disabled={includePatternBG}
+                                            onCheckedChange={(value) =>
+                                                setAutoCrop(value as boolean)
+                                            }
+                                        />
+                                        <div className="flex flex-col">
+                                            <label
+                                                htmlFor="auto-crop-checkbox"
+                                                className={`cursor-pointer font-medium ${includePatternBG ? 'text-muted-foreground' : ''}`}
+                                            >
+                                                Обрезать пустые поля
+                                            </label>
+                                            <span className="text-sm text-muted-foreground">
+                                                Автоматически обрезать пустые
+                                                поля вокруг диаграммы
+                                                {includePatternBG && (
+                                                    <span className="mt-1 block text-xs italic">
+                                                        (Недоступно при
+                                                        включенном фоновом
+                                                        паттерне)
+                                                    </span>
+                                                )}
+                                            </span>
+                                        </div>
+                                    </div>
                                 </div>
                             </AccordionContent>
                         </AccordionItem>
@@ -165,11 +298,28 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
                             {t('export_image_dialog.cancel')}
                         </Button>
                     </DialogClose>
-                    <DialogClose asChild>
-                        <Button onClick={handleExport}>
-                            {t('export_image_dialog.export')}
-                        </Button>
-                    </DialogClose>
+                    <Button
+                        onClick={async () => {
+                            console.log(
+                                `[export-button] Нажата кнопка экспорта, формат: ${format}`
+                            );
+                            try {
+                                await handleExport();
+                                console.log(
+                                    '[export-button] Экспорт успешно завершен'
+                                );
+                                // Закрываем диалог только после завершения экспорта
+                                closeExportImageDialog();
+                            } catch (error) {
+                                console.error(
+                                    '[export-button] Ошибка при экспорте:',
+                                    error
+                                );
+                            }
+                        }}
+                    >
+                        {t('export_image_dialog.export')}
+                    </Button>
                 </DialogFooter>
             </DialogContent>
         </Dialog>

--- a/src/dialogs/export-image-dialog/export-image-dialog.tsx
+++ b/src/dialogs/export-image-dialog/export-image-dialog.tsx
@@ -55,7 +55,7 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
         setAutoCrop(DEFAULT_AUTO_CROP);
     }, [dialog.open]);
 
-    // Выключаем опцию обрезки, если включен фоновый паттерн
+    // Disable cropping option if background pattern is enabled
     useEffect(() => {
         if (includePatternBG && autoCrop) {
             setAutoCrop(false);
@@ -66,17 +66,17 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
     const handleExport = useCallback(async () => {
         try {
             console.log(
-                `[export-dialog] Экспорт диаграммы в формате: ${format}`
+                `[export-dialog] Exporting diagram in format: ${format}`
             );
 
-            // Отдельная обработка для формата SVG
+            // Separate processing for SVG format
             if (format === 'svg') {
                 console.log(
-                    '[export-dialog] Используем метод загрузки через fetch для SVG'
+                    '[export-dialog] Using fetch method for SVG download'
                 );
 
                 try {
-                    // Получаем SVG данные
+                    // Get SVG data
                     const imageUrl = await exportImage('svg', {
                         transparent,
                         includePatternBG,
@@ -84,82 +84,80 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
                     });
 
                     console.log(
-                        '[export-dialog] Получен SVG URL, длина:',
+                        '[export-dialog] Received SVG URL, length:',
                         imageUrl.length
                     );
 
-                    // Используем fetch для получения данных SVG
+                    // Use fetch to get SVG data
                     const response = await fetch(imageUrl);
                     const blob = await response.blob();
 
                     console.log(
-                        '[export-dialog] Создан blob для SVG, размер:',
+                        '[export-dialog] Created blob for SVG, size:',
                         blob.size
                     );
 
-                    // Создаем файл и начинаем загрузку
+                    // Create file and start download
                     const url = window.URL.createObjectURL(blob);
                     const filename = 'diagram.svg';
 
-                    // Создаем новый элемент ссылки для загрузки
+                    // Create download link element
                     const downloadLink = document.createElement('a');
                     downloadLink.href = url;
                     downloadLink.download = filename;
                     downloadLink.style.display = 'none';
 
-                    // Добавляем в DOM, кликаем и удаляем
+                    // Add to DOM, click and remove
                     document.body.appendChild(downloadLink);
-                    console.log('[export-dialog] Начинаем загрузку SVG файла');
+                    console.log('[export-dialog] Starting SVG file download');
                     downloadLink.click();
 
-                    // Даем время на скачивание перед удалением
+                    // Allow time for download before removal
                     await new Promise((resolve) => setTimeout(resolve, 300));
 
                     document.body.removeChild(downloadLink);
                     window.URL.revokeObjectURL(url);
-                    console.log('[export-dialog] Загрузка SVG завершена');
+                    console.log('[export-dialog] SVG download completed');
 
                     return true;
                 } catch (error) {
-                    console.error('Ошибка при экспорте SVG:', error);
+                    console.error('Error exporting SVG:', error);
                     throw error;
                 }
             } else {
-                // Для PNG и JPEG применяем стандартный метод экспорта
+                // For PNG and JPEG use standard export method
                 console.log(
-                    `[export-dialog] Экспорт ${format} с параметрами: масштаб=${scale}, прозрачность=${transparent}`
+                    `[export-dialog] Exporting ${format} with parameters: scale=${scale}, transparency=${transparent}`
                 );
 
-                // Получаем изображение
+                // Get the image
                 const imageUrl = await exportImage(format, {
                     transparent,
                     includePatternBG,
                     scale: Number(scale),
                 });
 
-                // Применяем автоматическую обрезку, если нужно
+                // Apply automatic cropping if needed
                 let finalImageUrl;
 
                 if (autoCrop && !includePatternBG) {
-                    console.log(
-                        '[export-dialog] Применяем автоматическую обрезку'
-                    );
+                    console.log('[export-dialog] Applying automatic cropping');
                     finalImageUrl = await autoCropImage(imageUrl, 50, format);
                 } else {
                     finalImageUrl = imageUrl;
                 }
 
-                // Создаем ссылку для скачивания
+                // Create download link
                 const link = document.createElement('a');
                 link.download = `diagram.${format}`;
                 link.href = finalImageUrl;
                 document.body.appendChild(link);
-                console.log(`[export-dialog] Запуск скачивания ${format}`);
+                console.log(`[export-dialog] Starting ${format} download`);
                 link.click();
                 document.body.removeChild(link);
             }
         } catch (error) {
-            console.error('Ошибка при экспорте изображения:', error);
+            console.error('Error exporting image:', error);
         }
     }, [exportImage, format, includePatternBG, transparent, scale, autoCrop]);
 
@@ -272,16 +270,19 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
                                                 htmlFor="auto-crop-checkbox"
                                                 className={`cursor-pointer font-medium ${includePatternBG ? 'text-muted-foreground' : ''}`}
                                             >
-                                                Обрезать пустые поля
+                                                {t(
+                                                    'export_image_dialog.crop_empty_space'
+                                                )}
                                             </label>
                                             <span className="text-sm text-muted-foreground">
-                                                Автоматически обрезать пустые
-                                                поля вокруг диаграммы
+                                                {t(
+                                                    'export_image_dialog.crop_description'
+                                                )}
                                                 {includePatternBG && (
                                                     <span className="mt-1 block text-xs italic">
-                                                        (Недоступно при
-                                                        включенном фоновом
-                                                        паттерне)
+                                                        {t(
+                                                            'export_image_dialog.crop_unavailable'
+                                                        )}
                                                     </span>
                                                 )}
                                             </span>
@@ -301,18 +302,18 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
                     <Button
                         onClick={async () => {
                             console.log(
-                                `[export-button] Нажата кнопка экспорта, формат: ${format}`
+                                `[export-button] Export button pressed, format: ${format}`
                             );
                             try {
                                 await handleExport();
                                 console.log(
-                                    '[export-button] Экспорт успешно завершен'
+                                    '[export-button] Export completed successfully'
                                 );
-                                // Закрываем диалог только после завершения экспорта
+                                // Close dialog only after export is complete
                                 closeExportImageDialog();
                             } catch (error) {
                                 console.error(
-                                    '[export-button] Ошибка при экспорте:',
+                                    '[export-button] Error during export:',
                                     error
                                 );
                             }

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -399,6 +399,9 @@ export const ar: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'قص المساحة الفارغة',
+            crop_description: 'قص المساحة الفارغة حول الرسم البياني تلقائيًا',
+            crop_unavailable: '(غير متوفر مع نمط الخلفية)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -400,6 +400,10 @@ export const bn: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'খালি স্থান কাটুন',
+            crop_description:
+                'ডায়াগ্রামের চারপাশের খালি স্থান স্বয়ংক্রিয়ভাবে কাটুন।',
+            crop_unavailable: '(পটভূমি প্যাটার্নের সাথে উপলব্ধ নয়)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -403,6 +403,10 @@ export const de: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'Leeren Bereich zuschneiden',
+            crop_description:
+                'Leeren Bereich um das Diagramm herum automatisch zuschneiden.',
+            crop_unavailable: '(Nicht verfügbar mit Hintergrundmuster)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -393,6 +393,9 @@ export const en = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'Crop empty space',
+            crop_description: 'Automatically crop empty space around diagram.',
+            crop_unavailable: '(Not available with background pattern)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -392,6 +392,10 @@ export const es: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'Recortar espacio vacío',
+            crop_description:
+                'Recortar automáticamente el espacio vacío alrededor del diagrama.',
+            crop_unavailable: '(No disponible con patrón de fondo)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -355,6 +355,10 @@ export const fr: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'Rogner les espaces vides',
+            crop_description:
+                'Rogner automatiquement les espaces vides autour du diagramme.',
+            crop_unavailable: '(Non disponible avec motif de fond)',
         },
 
         multiple_schemas_alert: {

--- a/src/i18n/locales/gu.ts
+++ b/src/i18n/locales/gu.ts
@@ -399,6 +399,9 @@ export const gu: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'ખાલી જગ્યા કાપો',
+            crop_description: 'આકૃતિની આજુબાજુની ખાલી જગ્યા આપમેળે કાપો.',
+            crop_unavailable: '(બેકગ્રાઉન્ડ પેટર્ન સાથે ઉપલબ્ધ નથી)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -402,6 +402,10 @@ export const hi: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'खाली स्थान काटें',
+            crop_description:
+                'आरेख के आसपास के खाली स्थान को स्वचालित रूप से काटें।',
+            crop_unavailable: '(पृष्ठभूमि पैटर्न के साथ उपलब्ध नहीं)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/id_ID.ts
+++ b/src/i18n/locales/id_ID.ts
@@ -398,6 +398,10 @@ export const id_ID: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'Potong ruang kosong',
+            crop_description:
+                'Secara otomatis memotong ruang kosong di sekitar diagram.',
+            crop_unavailable: '(Tidak tersedia dengan pola latar belakang)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -406,6 +406,10 @@ export const ja: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: '空白部分をトリミング',
+            crop_description: '図の周りの空白部分を自動的にトリミングします。',
+            crop_unavailable:
+                '(背景パターンを使用している場合は利用できません)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -398,6 +398,9 @@ export const ko_KR: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: '빈 공간 자르기',
+            crop_description: '다이어그램 주변의 빈 공간을 자동으로 자릅니다.',
+            crop_unavailable: '(배경 패턴을 사용할 때는 사용할 수 없음)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/mr.ts
+++ b/src/i18n/locales/mr.ts
@@ -405,6 +405,9 @@ export const mr: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'रिकामी जागा कापा',
+            crop_description: 'आकृतीभोवती रिकामी जागा स्वयंचलितपणे कापा.',
+            crop_unavailable: '(बॅकग्राउंड पॅटर्नसह उपलब्ध नाही)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -403,6 +403,10 @@ export const ne: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'खाली ठाउँ काट्नुहोस्',
+            crop_description:
+                'चित्रको वरिपरिको खाली ठाउँ स्वचालित रूपमा काट्नुहोस्।',
+            crop_unavailable: '(पृष्ठभूमि प्याटर्नको साथमा उपलब्ध छैन)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -401,6 +401,10 @@ export const pt_BR: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'Recortar espaço vazio',
+            crop_description:
+                'Recortar automaticamente o espaço vazio ao redor do diagrama.',
+            crop_unavailable: '(Não disponível com padrão de fundo)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -392,12 +392,15 @@ export const ru: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Отменить',
             export: 'Экспортировать',
-            // TODO: Translate
-            advanced_options: 'Advanced Options',
-            pattern: 'Include background pattern',
-            pattern_description: 'Add subtle grid pattern to background.',
-            transparent: 'Transparent background',
-            transparent_description: 'Remove background color from image.',
+            advanced_options: 'Дополнительные настройки',
+            pattern: 'Включить фоновый паттерн',
+            pattern_description: 'Добавить сетку на фон изображения.',
+            transparent: 'Прозрачный фон',
+            transparent_description: 'Удалить цвет фона изображения.',
+            crop_empty_space: 'Обрезать пустые поля',
+            crop_description:
+                'Автоматически обрезать пустые поля вокруг диаграммы.',
+            crop_unavailable: '(Недоступно при включенном фоновом паттерне)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/te.ts
+++ b/src/i18n/locales/te.ts
@@ -402,6 +402,10 @@ export const te: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'ఖాళీ స్థలాన్ని కత్తిరించు',
+            crop_description:
+                'చిత్రం చుట్టూ ఉన్న ఖాళీ స్థలాన్ని స్వయంచాలకంగా కత్తిరించు.',
+            crop_unavailable: '(నేపథ్య ప్యాటర్న్ తో లభ్యం కాదు)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -393,6 +393,10 @@ export const tr: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'Boş alanları kırp',
+            crop_description:
+                'Diyagramın etrafındaki boş alanları otomatik olarak kırp.',
+            crop_unavailable: '(Arka plan deseni ile kullanılamaz)',
         },
         new_table_schema_dialog: {
             title: 'Şema Seç',

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -398,6 +398,10 @@ export const uk: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'Обрізати порожні області',
+            crop_description:
+                'Автоматично обрізати порожні області навколо діаграми.',
+            crop_unavailable: '(Недоступно з фоновим візерунком)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -397,6 +397,9 @@ export const vi: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: 'Cắt bỏ khoảng trống',
+            crop_description: 'Tự động cắt bỏ khoảng trống xung quanh sơ đồ.',
+            crop_unavailable: '(Không khả dụng với mẫu nền)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -393,6 +393,9 @@ export const zh_CN: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: '裁剪空白区域',
+            crop_description: '自动裁剪图表周围的空白区域。',
+            crop_unavailable: '(使用背景图案时不可用)',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -392,6 +392,9 @@ export const zh_TW: LanguageTranslation = {
             pattern_description: 'Add subtle grid pattern to background.',
             transparent: 'Transparent background',
             transparent_description: 'Remove background color from image.',
+            crop_empty_space: '裁剪空白區域',
+            crop_description: '自動裁剪圖表周圍的空白區域。',
+            crop_unavailable: '(使用背景圖案時不可用)',
         },
 
         new_table_schema_dialog: {

--- a/src/pages/editor-page/top-navbar/menu/menu.tsx
+++ b/src/pages/editor-page/top-navbar/menu/menu.tsx
@@ -32,6 +32,7 @@ import { useTheme } from '@/hooks/use-theme';
 import { useLocalConfig } from '@/hooks/use-local-config';
 import { useNavigate } from 'react-router-dom';
 import { useAlert } from '@/context/alert-context/alert-context';
+import { autoCropImage } from '@/utils/image-utils';
 
 export interface MenuProps {}
 
@@ -106,8 +107,11 @@ export const Menu: React.FC<MenuProps> = () => {
                 includePatternBG: false, // Without background pattern
             });
 
+            // Apply auto-cropping to remove empty spaces
+            const croppedPngUrl = await autoCropImage(pngUrl, 50, 'png');
+
             // Get Blob from URL
-            const response = await fetch(pngUrl);
+            const response = await fetch(croppedPngUrl);
             const blob = await response.blob();
 
             // Copy to clipboard
@@ -117,7 +121,7 @@ export const Menu: React.FC<MenuProps> = () => {
                 }),
             ]);
 
-            console.log('Diagram copied to clipboard as PNG');
+            console.log('Diagram copied to clipboard as PNG (auto-cropped)');
         } catch (error) {
             console.error('Error copying PNG to clipboard:', error);
         }

--- a/src/pages/editor-page/top-navbar/menu/menu.tsx
+++ b/src/pages/editor-page/top-navbar/menu/menu.tsx
@@ -90,6 +90,7 @@ export const Menu: React.FC<MenuProps> = () => {
     };
 
     const exportSVG = useCallback(() => {
+        // Direct export of SVG with default settings
         exportImage('svg', {
             scale: 1,
             transparent: true,

--- a/src/utils/image-utils.ts
+++ b/src/utils/image-utils.ts
@@ -1,0 +1,158 @@
+/**
+ * Utility functions for image processing
+ */
+
+/**
+ * Auto-crops image by removing transparent/white space from edges
+ * @param dataUrl - image data URL to crop
+ * @param padding - optional padding to add around the cropped area (in pixels)
+ * @param format - image format ('png' or 'jpeg')
+ * @returns Promise with cropped image data URL
+ */
+export const autoCropImage = async (
+    dataUrl: string,
+    padding: number = 30,
+    format: string = 'png'
+): Promise<string> => {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => {
+            try {
+                // Create canvas with the original image dimensions
+                const canvas = document.createElement('canvas');
+                const ctx = canvas.getContext('2d');
+                if (!ctx) {
+                    reject(new Error('Could not get canvas context'));
+                    return;
+                }
+
+                canvas.width = img.width;
+                canvas.height = img.height;
+
+                // Draw the image on the canvas
+                ctx.drawImage(img, 0, 0);
+
+                // Get image data to analyze pixels
+                const imageData = ctx.getImageData(
+                    0,
+                    0,
+                    canvas.width,
+                    canvas.height
+                );
+                const data = imageData.data;
+
+                // Find the bounds of non-transparent/non-white pixels
+                let minX = canvas.width;
+                let minY = canvas.height;
+                let maxX = 0;
+                let maxY = 0;
+
+                // Сканируем с шагом для ускорения
+                const step = 3; // используем шаг 3 для баланса между скоростью и точностью
+
+                // Сканирование пикселей
+                for (let y = 0; y < canvas.height; y += step) {
+                    for (let x = 0; x < canvas.width; x += step) {
+                        const idx = (y * canvas.width + x) * 4;
+
+                        // Анализируем цвет пикселя для определения содержимого
+                        const r = data[idx];
+                        const g = data[idx + 1];
+                        const b = data[idx + 2];
+                        const a = data[idx + 3];
+
+                        // Улучшенный алгоритм определения контента:
+                        // 1. Считаем содержимым пиксели с большой непрозрачностью и не белые
+                        // 2. Также проверяем, если есть значительная разница между RGB каналами
+
+                        // Проверка на непрозрачный и не белый пиксель
+                        const isNotTransparent = a > 30;
+                        const isNotWhite = !(r > 235 && g > 235 && b > 235);
+
+                        // Проверка на достаточную разницу между RGB каналами
+                        const maxDiff = Math.max(
+                            Math.abs(r - g),
+                            Math.abs(r - b),
+                            Math.abs(g - b)
+                        );
+                        const hasColorVariation = maxDiff > 15;
+
+                        // Проверка на достаточно темный цвет (не близкий к белому)
+                        const brightness = (r + g + b) / 3;
+                        const isDark = brightness < 230;
+
+                        // Объединяем условия
+                        const isContentPixel =
+                            isNotTransparent &&
+                            (isNotWhite || hasColorVariation || isDark);
+
+                        if (isContentPixel) {
+                            minX = Math.min(minX, x);
+                            minY = Math.min(minY, y);
+                            maxX = Math.max(maxX, x);
+                            maxY = Math.max(maxY, y);
+                        }
+                    }
+                }
+
+                // Add padding
+                minX = Math.max(0, minX - padding);
+                minY = Math.max(0, minY - padding);
+                maxX = Math.min(canvas.width, maxX + padding);
+                maxY = Math.min(canvas.height, maxY + padding);
+
+                // Проверяем, нашли ли мы какой-либо контент
+                if (minX >= maxX || minY >= maxY) {
+                    // Контент не найден, возвращаем оригинальное изображение
+                    resolve(dataUrl);
+                    return;
+                }
+
+                // Calculate new dimensions
+                const width = maxX - minX;
+                const height = maxY - minY;
+
+                // Создаем новый canvas для обрезанного изображения
+                console.log('Создаем обрезанный canvas', width, height);
+                const croppedCanvas = document.createElement('canvas');
+                const croppedCtx = croppedCanvas.getContext('2d');
+                if (!croppedCtx) {
+                    reject(new Error('Could not get cropped canvas context'));
+                    return;
+                }
+
+                // Set dimensions for the cropped canvas
+                croppedCanvas.width = width;
+                croppedCanvas.height = height;
+
+                // Draw the cropped region into the new canvas
+                croppedCtx.drawImage(
+                    canvas,
+                    minX,
+                    minY,
+                    width,
+                    height, // Source rectangle
+                    0,
+                    0,
+                    width,
+                    height // Destination rectangle
+                );
+
+                // Конвертируем canvas в data URL
+                const mimeType = format === 'jpeg' ? 'image/jpeg' : 'image/png';
+
+                const croppedDataUrl = croppedCanvas.toDataURL(mimeType);
+
+                resolve(croppedDataUrl);
+            } catch (error) {
+                reject(error);
+            }
+        };
+
+        img.onerror = (error) => {
+            reject(error);
+        };
+
+        img.src = dataUrl;
+    });
+};


### PR DESCRIPTION
This PR refactors the image export functionality with the following key changes:

- **SVG Export:** Reverted SVG export to direct download/new tab, bypassing the export dialog. SVG auto-cropping functionality has been removed.
- **Image Cropping:** Significantly improved the autoCropImage algorithm for PNG/JPEG formats, enhancing content detection.
- **UI/UX:** Removed the cropping confirmation dialog for a more streamlined export flow.

### Screenshots

Export dialog:
<img width="1862" alt="Screenshot 2025-05-30 at 11 21 06" src="https://github.com/user-attachments/assets/394525c8-08be-4a37-b1f3-8f3d9eb3069b" />

Result:
![diagram (26)](https://github.com/user-attachments/assets/97c672de-0b5f-47a5-867e-3f36d2d39ea9)

